### PR TITLE
Add keepers field to cache store

### DIFF
--- a/cache/getproviderschema.go
+++ b/cache/getproviderschema.go
@@ -12,7 +12,7 @@ func (s *RawProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov
 
 	cfgSchema := GetProviderConfigSchema()
 
-	resSchema := GetProviderResourceSchema()
+	resSchema := GetProviderResourceSchemas()
 
 	log.Println("--------------------------GetProviderSchema Called------------------------------")
 

--- a/cache/plan.go
+++ b/cache/plan.go
@@ -87,7 +87,8 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 		return resp, nil
 	}
 
-	if proposedVal["timestamp"].IsNull() {
+	// if timestamp is null, this is a create. If the keepers have changed, we do the same steps (its like a re-create)
+	if proposedVal["timestamp"].IsNull() || !proposedVal["keepers"].Equal(priorVal["keepers"]) {
 		// plan for Create
 		proposedVal["timestamp"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
 		propStateVal := tftypes.NewValue(proposedState.Type(), proposedVal)
@@ -106,7 +107,7 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 		resp.PlannedState = &plannedState
 	} else {
 		// plan for Update
-		// NO-OP
+		// This should be a no-op
 		resp.PlannedState = req.PriorState
 	}
 

--- a/cache/provider.go
+++ b/cache/provider.go
@@ -31,7 +31,7 @@ func GetObjectTypeFromSchema(schema *tfprotov5.Schema) tftypes.Type {
 
 // GetResourceType returns the tftypes.Type of a resource of type 'name'
 func GetResourceType(name string) (tftypes.Type, error) {
-	sch := GetProviderResourceSchema()
+	sch := GetProviderResourceSchemas()
 	rsch, ok := sch[name]
 	if !ok {
 		return tftypes.DynamicPseudoType, fmt.Errorf("unknown resource %s - cannot find schema", name)
@@ -40,31 +40,22 @@ func GetResourceType(name string) (tftypes.Type, error) {
 }
 
 // GetProviderResourceSchema contains the definitions of all supported resources
-func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
+func GetProviderResourceSchemas() map[string]*tfprotov5.Schema {
 	return map[string]*tfprotov5.Schema{
-		"cache_store": {
-			Version: 1,
-			Block: &tfprotov5.SchemaBlock{
-				BlockTypes: []*tfprotov5.SchemaNestedBlock{},
-				Attributes: []*tfprotov5.SchemaAttribute{
-					{
-						Name:        "timestamp",
-						Type:        tftypes.String,
-						Required:    false,
-						Computed:    true,
-						Optional:    false,
-						Description: "The timestamp this cached value was created",
-					},
-					{
-						Name:        "value",
-						Type:        tftypes.DynamicPseudoType,
-						Required:    true,
-						Optional:    false,
-						Computed:    false,
-						Description: "The value to cache.",
-					},
-				},
-			},
-		},
+		"cache_store": GetLatestCacheStoreSchema(),
+	}
+}
+
+// GetProviderResourceSchema contains the definitions of all supported resources
+func GetProviderResourceSchemasByVersion(version int64) map[string]*tfprotov5.Schema {
+	return map[string]*tfprotov5.Schema{
+		"cache_store": GetCacheStoreSchemaByVersion(version),
+	}
+}
+
+// GetProviderResourceSchema contains the definitions of all supported resources
+func GetProviderResourceUpgradeFunctions() map[string]func(resourceValue tftypes.Value, fromVersion int64) (tftypes.Value, error) {
+	return map[string]func(resourceValue tftypes.Value, fromVersion int64) (tftypes.Value, error){
+		"cache_store": CacheStoreUpgradeResource,
 	}
 }

--- a/cache/read.go
+++ b/cache/read.go
@@ -61,7 +61,7 @@ func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Rea
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
 			Summary:  "Current state of resource has no 'value' attribute",
-			Detail:   "This should not happen. The state may be incomplete or corrupted.\nIf this error is reproducible, plese report issue to provider maintainers.",
+			Detail:   "This should not happen. The state may be incomplete or corrupted.\nIf this error is reproducible, please report issue to provider maintainers.",
 		})
 		return resp, nil
 	}

--- a/cache/store.go
+++ b/cache/store.go
@@ -1,0 +1,99 @@
+package cache
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var CACHE_STORE_V2 = tfprotov5.Schema{
+	Version: 2,
+	Block: &tfprotov5.SchemaBlock{
+		BlockTypes: []*tfprotov5.SchemaNestedBlock{},
+		Attributes: []*tfprotov5.SchemaAttribute{
+			{
+				Name:        "timestamp",
+				Type:        tftypes.String,
+				Required:    false,
+				Computed:    true,
+				Optional:    false,
+				Description: "The timestamp this cached value was created",
+			},
+			{
+				Name:        "value",
+				Type:        tftypes.DynamicPseudoType,
+				Required:    true,
+				Optional:    false,
+				Computed:    false,
+				Description: "The value to cache.",
+			},
+			{
+				Name:        "keepers",
+				Type:        tftypes.Map{ElementType: tftypes.DynamicPseudoType},
+				Required:    false,
+				Optional:    true,
+				Computed:    false,
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+			},
+		},
+	},
+}
+
+var CACHE_STORE_V1 = tfprotov5.Schema{
+	Version: 2,
+	Block: &tfprotov5.SchemaBlock{
+		BlockTypes: []*tfprotov5.SchemaNestedBlock{},
+		Attributes: []*tfprotov5.SchemaAttribute{
+			{
+				Name:        "timestamp",
+				Type:        tftypes.String,
+				Required:    false,
+				Computed:    true,
+				Optional:    false,
+				Description: "The timestamp this cached value was created",
+			},
+			{
+				Name:        "value",
+				Type:        tftypes.DynamicPseudoType,
+				Required:    true,
+				Optional:    false,
+				Computed:    false,
+				Description: "The value to cache.",
+			},
+		},
+	},
+}
+
+func GetLatestCacheStoreSchema() *tfprotov5.Schema {
+	return &CACHE_STORE_V2
+}
+
+func GetCacheStoreSchemaByVersion(version int64) *tfprotov5.Schema {
+	switch version {
+	case 2:
+		return &CACHE_STORE_V2
+	case 1:
+		return &CACHE_STORE_V1
+	default:
+		return nil
+	}
+}
+
+func CacheStoreUpgradeResource(priorValue tftypes.Value, fromVersion int64) (tftypes.Value, error) {
+	if fromVersion < 2 {
+		return CacheStoreUpgradeResourceV1ToV2(priorValue)
+	}
+	return priorValue, nil
+}
+
+func CacheStoreUpgradeResourceV1ToV2(priorValue tftypes.Value) (tftypes.Value, error) {
+	updatedValue := make(map[string]tftypes.Value)
+	err := priorValue.As(&updatedValue)
+	if err != nil {
+		return priorValue, err
+	}
+	updatedValue["keepers"] = tftypes.NewValue(tftypes.Map{ElementType: tftypes.DynamicPseudoType}, nil)
+
+	newValue := tftypes.NewValue(GetObjectTypeFromSchema(&CACHE_STORE_V2), updatedValue)
+
+	return newValue, nil
+}


### PR DESCRIPTION
closes: https://github.com/massdriver-cloud/massdriver/issues/1096

This is a gnarly change that took a while to wrap my mind around. The `cache_store` doesn't currently have a way to trigger a recreate of an external value changes - similar to the `keepers` field in the `random` provider.

The difficulty here is that in order for the `cache_store` resource to accept a dynamic type, we have to use `terraform-plugin-go` instead of the `terraform-plugin-framework`. This makes **everything** much harder since we don't have the utilities functions. The random provider implements the replacement logic of keepers very easily: https://github.com/hashicorp/terraform-plugin-framework

Since we don't use the framework, we have to do it all manually. One of the biggest issues was with the additional of the new attribute we have to dynamically update the schema version to inform the *old* state that a new variable exists.

Edit: I'd like to review against this before merging: https://github.com/hashicorp/terraform-provider-random/blob/main/internal/provider/resource_password.go